### PR TITLE
Make navbar logo area a single link

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -12,7 +12,7 @@ export default function DashboardPage() {
         <KPI label="Estimated Annual Return" value={9.8} isPercent />
         <KPI label="Lifetime Earnings" value={2450.75} />
       </div>
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <ChartCard kind="line" title="Portfolio Performance" />
         <ChartCard kind="doughnut" title="Portfolio Allocation" />
       </div>

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -10,10 +10,10 @@ export default function NavBar() {
   return (
     <header className="bg-white shadow-sm sticky top-0 z-50" role="banner">
       <div className="container mx-auto px-6 py-4 flex justify-between items-center">
-        <div className="flex items-center gap-2">
-          <svg aria-hidden xmlns="http://www.w3.org/2000/svg" className="h-8 w-8 text-brand-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path><polyline points="9 22 9 12 15 12 15 22"></polyline></svg>
-          <Link href="/" className="text-2xl font-bold text-gray-900">Nest Fund</Link>
-        </div>
+        <Link href="/" className="flex items-center gap-2">
+          <Image src="/logo.png" alt="Nest Fund logo" width={32} height={32} priority />
+          <span className="text-2xl font-bold text-gray-900">Nest Fund</span>
+        </Link>
         <button className="md:hidden" aria-controls="main-nav" aria-expanded={open} onClick={() => setOpen(v => !v)}>
           <span className="sr-only">Toggle navigation</span>☰
         </button>

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -11,7 +11,7 @@ export default function NavBar() {
     <header className="bg-white shadow-sm sticky top-0 z-50" role="banner">
       <div className="container mx-auto px-6 py-4 flex justify-between items-center">
         <Link href="/" className="flex items-center gap-2">
-          <Image src="/logo.png" alt="Nest Fund logo" width={64} height={64} priority />
+          <Image src="/logo.png" alt="Nest Fund logo" width={128} height={128} priority />
           <span className="text-2xl font-bold text-gray-900">Nest Fund</span>
         </Link>
         <button className="md:hidden" aria-controls="main-nav" aria-expanded={open} onClick={() => setOpen(v => !v)}>

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -11,7 +11,7 @@ export default function NavBar() {
     <header className="bg-white shadow-sm sticky top-0 z-50" role="banner">
       <div className="container mx-auto px-6 py-4 flex justify-between items-center">
         <Link href="/" className="flex items-center gap-2">
-          <Image src="/logo.png" alt="Nest Fund logo" width={32} height={32} priority />
+          <Image src="/logo.png" alt="Nest Fund logo" width={64} height={64} priority />
           <span className="text-2xl font-bold text-gray-900">Nest Fund</span>
         </Link>
         <button className="md:hidden" aria-controls="main-nav" aria-expanded={open} onClick={() => setOpen(v => !v)}>


### PR DESCRIPTION
## Summary
- replace the navbar logo wrapper with a single Link so the entire logo area is clickable
- render the brand mark with Next Image and keep the text label for accessibility

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd84e1c670833084bca9414d2bdcc5